### PR TITLE
Weapon, ItemData 리팩토링

### DIFF
--- a/Assets/Scriptable Object/Item/Item 0.asset
+++ b/Assets/Scriptable Object/Item/Item 0.asset
@@ -19,10 +19,11 @@ MonoBehaviour:
   itemName: "\uC0BD"
   itemDesc: "\uB370\uBBF8\uC9C0 {0}% \uC99D\uAC00\n\uD68C\uC804\uCCB4 {1}\uAC1C \uCD94\uAC00"
   itemIcon: {fileID: -181907988, guid: d71a3dc7aa20fad4f9a99fc76a9254ba, type: 3}
-  baseDamage: 4.5
+  baseDamage: 3.5
   baseCount: 1
   baseSpeed: 150
   baseRate: 0
+  basePer: 0
   nextDamages:
   - 0.5
   - 0.5
@@ -35,7 +36,7 @@ MonoBehaviour:
   - 0.1
   - 0.1
   - 0.1
-  - 0.1
+  - 0.5
   nextMoveSpeed:
   - 0
   - 0

--- a/Assets/Scriptable Object/Item/Item 1.asset
+++ b/Assets/Scriptable Object/Item/Item 1.asset
@@ -19,17 +19,18 @@ MonoBehaviour:
   itemName: "\uC5FD\uCD1D"
   itemDesc: "\uB370\uBBF8\uC9C0 {0}% \uC99D\uAC00\n\uAD00\uD1B5\uB825 {1} \uCD94\uAC00"
   itemIcon: {fileID: -205726582, guid: d71a3dc7aa20fad4f9a99fc76a9254ba, type: 3}
-  baseDamage: 5
+  baseDamage: 7
   baseCount: 1
   baseSpeed: 0
-  baseRate: 0.5
+  baseRate: 1
+  basePer: 1
   nextDamages:
   - 0.35
   - 0.35
   - 0.35
   - 0.35
   - 0.5
-  nextCounts: 0000000001000000000000000000000000000000
+  nextCounts: 0000000000000000000000000000000001000000
   nextWeaponSpeed:
   - 0
   - 0
@@ -48,6 +49,6 @@ MonoBehaviour:
   - 0
   - 0
   - 0
-  nextPer: 0100000000000000010000000100000001000000
+  nextPer: 0100000001000000010000000100000001000000
   projectile: {fileID: 2773070785237260793, guid: df7d29b40a8754e978122ef4f9bd443d, type: 3}
   hand: {fileID: -353751291, guid: 0d5e657ee5a074e4baa53d5b248a01d2, type: 3}

--- a/Assets/Scriptable Object/Item/Item 4.asset
+++ b/Assets/Scriptable Object/Item/Item 4.asset
@@ -23,6 +23,7 @@ MonoBehaviour:
   baseCount: 3
   baseSpeed: 150
   baseRate: 0.5
+  basePer: 0
   nextDamages:
   - 0.5
   - 0.5
@@ -47,7 +48,7 @@ MonoBehaviour:
   - 0
   - 0
   - 0
-  - 0
+  - 0.2
   nextPer: 0000000000000000000000000000000000000000
   projectile: {fileID: 5588354483150353491, guid: 8286316a87df7462b9673becf5f5692c, type: 3}
   hand: {fileID: -1972582131, guid: 0d5e657ee5a074e4baa53d5b248a01d2, type: 3}

--- a/Assets/Scriptable Object/Item/Item 5.asset
+++ b/Assets/Scriptable Object/Item/Item 5.asset
@@ -22,14 +22,15 @@ MonoBehaviour:
   baseDamage: 4.5
   baseCount: 3
   baseSpeed: 250
-  baseRate: 0
+  baseRate: 0.5
+  basePer: 0
   nextDamages:
   - 0.5
   - 0.5
   - 0.5
   - 0.5
   - 0.5
-  nextCounts: 0100000001000000010000000100000001000000
+  nextCounts: 0000000000000000000000000000000001000000
   nextWeaponSpeed:
   - 0.1
   - 0.1
@@ -47,7 +48,7 @@ MonoBehaviour:
   - 0
   - 0
   - 0
-  - 0
+  - 0.2
   nextPer: 0000000000000000000000000000000000000000
   projectile: {fileID: 5588354483150353491, guid: 8d8cbaf5750164895965addae327ad77, type: 3}
   hand: {fileID: 1349035616, guid: 0d5e657ee5a074e4baa53d5b248a01d2, type: 3}

--- a/Assets/Scriptable Object/Item/Item 6.asset
+++ b/Assets/Scriptable Object/Item/Item 6.asset
@@ -20,10 +20,11 @@ MonoBehaviour:
   itemDesc: "\uB370\uBBF8\uC9C0 {0}% \uC99D\uAC00\n\uAD00\uD1B5\uB825 {1} \uCD94\uAC00\n\uC5F0\uC0AC\uC18D\uB3C4\uBE60\uB984
     \uAD00\uD1B5\uB0AE\uC74C"
   itemIcon: {fileID: 563336626, guid: d71a3dc7aa20fad4f9a99fc76a9254ba, type: 3}
-  baseDamage: 3
+  baseDamage: 4
   baseCount: 0
   baseSpeed: 0
-  baseRate: 0.7
+  baseRate: 2
+  basePer: 0
   nextDamages:
   - 0.35
   - 0.35
@@ -45,10 +46,10 @@ MonoBehaviour:
   - 0
   nextRate:
   - 0.1
-  - 0
-  - 0
   - 0.1
-  - 0
-  nextPer: 0100000000000000010000000100000001000000
+  - 0.1
+  - 0.1
+  - 0.1
+  nextPer: 0000000000000000000000000000000001000000
   projectile: {fileID: 2773070785237260793, guid: df7d29b40a8754e978122ef4f9bd443d, type: 3}
   hand: {fileID: -144335857, guid: 0d5e657ee5a074e4baa53d5b248a01d2, type: 3}

--- a/Assets/Scriptable Object/Item/Item 7.asset
+++ b/Assets/Scriptable Object/Item/Item 7.asset
@@ -23,14 +23,15 @@ MonoBehaviour:
   baseDamage: 1
   baseCount: 3
   baseSpeed: 0
-  baseRate: 0.1
+  baseRate: 0.5
+  basePer: 0
   nextDamages:
   - 0.35
   - 0.35
   - 0.35
   - 0.35
   - 0.5
-  nextCounts: 0000000001000000000000000000000000000000
+  nextCounts: 0100000001000000010000000100000001000000
   nextWeaponSpeed:
   - 0
   - 0
@@ -49,6 +50,6 @@ MonoBehaviour:
   - 0
   - 0
   - 0
-  nextPer: 0100000000000000010000000100000001000000
+  nextPer: 0000000000000000000000000000000002000000
   projectile: {fileID: 5588354483150353491, guid: 1ac08c3500f53445dbf0897c1f825b7a, type: 3}
   hand: {fileID: 1772703093, guid: 0d5e657ee5a074e4baa53d5b248a01d2, type: 3}

--- a/Assets/Scriptable Object/Player/Character 0.asset
+++ b/Assets/Scriptable Object/Player/Character 0.asset
@@ -19,4 +19,4 @@ MonoBehaviour:
   weaponRate: 1
   damage: 1
   count: 0
-  initWeaponId: 7
+  initWeaponId: 0

--- a/Assets/Scripts/AchieveManager.cs
+++ b/Assets/Scripts/AchieveManager.cs
@@ -11,7 +11,7 @@ public class AchieveManager : MonoBehaviour
     public GameObject uiNotice;
     
     
-    enum Achieve 
+    private enum Achieve 
     { 
         UnlockPotato,
         UnlockBean, 

--- a/Assets/Scripts/Armor.cs
+++ b/Assets/Scripts/Armor.cs
@@ -27,9 +27,9 @@ public class Armor : MonoBehaviour
         
         foreach (Weapon weapon in weapons)
         {
-            weapon.damageMultiplier += damage;
-            weapon.speed += weaponSpeed;
-            weapon.rate += weaponRate;
+            weapon.WBI.damageMultiplier += damage;
+            weapon.WBI.speedMultiplier += weaponSpeed;
+            weapon.WBI.rateMultiplier += weaponRate;
         }
     }
 }

--- a/Assets/Scripts/Bullet.cs
+++ b/Assets/Scripts/Bullet.cs
@@ -4,11 +4,12 @@ using Vector3 = UnityEngine.Vector3;
 
 public class Bullet : MonoBehaviour
 {
-    public int id;
-    public float damage;
-    public ItemData.WeaponType weaponType;
-    public int per;
-    public float speed;
+    // public int id;
+    // public float damage;
+    // public ItemData.WeaponType WeaponInfo.type;
+    // public int per;
+    // public float speed;
+    public WeaponInfo WeaponInfo;
     
     private Rigidbody2D _rigid;
     private SpriteRenderer _spriter;
@@ -23,30 +24,26 @@ public class Bullet : MonoBehaviour
 
     private void FixedUpdate()
     {
-        if (weaponType == ItemData.WeaponType.Melee)
+        if (WeaponInfo.type == ItemData.WeaponType.Melee)
         {
-            if (id == 4)
+            if (WeaponInfo.ID == 4)
             {
                transform.rotation = Quaternion.FromToRotation(Vector3.up, _player.dir);
                transform.localPosition = transform.up * 2f;
             }
-            if (id == 5)
-                transform.RotateAround(_player.transform.position, Vector3.forward, speed * Time.deltaTime);
+            if (WeaponInfo.ID == 5)
+                transform.RotateAround(_player.transform.position, Vector3.forward, WeaponInfo.Speed() * Time.deltaTime);
         }
     }
 
-    public void Init(float damage, int per, Vector3 dir, ItemData.WeaponType weaponType, int id, float speed)
+    public void Init(WeaponInfo info, Vector3 dir)
     {
-        this.id = id;
-        this.damage = damage;
-        this.per = per;
-        this.weaponType = weaponType;
-        this.speed = speed;
-        if (id == 5)
+        WeaponInfo = info;
+        if (WeaponInfo.ID == 5)
         {
             _spriter.flipX = dir != Vector3.down;
         }
-        if (weaponType == ItemData.WeaponType.Range)
+        if (WeaponInfo.type == ItemData.WeaponType.Range)
         {
             _rigid.velocity = dir * 10;
         }
@@ -54,10 +51,10 @@ public class Bullet : MonoBehaviour
 
     private void OnTriggerEnter2D(Collider2D other)
     {
-        if (!other.CompareTag("Enemy") || weaponType != ItemData.WeaponType.Range)
+        if (!other.CompareTag("Enemy") || WeaponInfo.type != ItemData.WeaponType.Range)
             return;
-        per--;
-        if (per < 0)
+        WeaponInfo.per--;
+        if (WeaponInfo.per < 0)
         {
             gameObject.SetActive(false);
         }
@@ -65,7 +62,7 @@ public class Bullet : MonoBehaviour
 
     private void OnTriggerExit2D(Collider2D other)
     {
-        if (!other.CompareTag("Area") || weaponType != ItemData.WeaponType.Range)
+        if (!other.CompareTag("Area") || WeaponInfo.type != ItemData.WeaponType.Range)
             return;
         gameObject.SetActive(false);
     }

--- a/Assets/Scripts/Enemy.cs
+++ b/Assets/Scripts/Enemy.cs
@@ -63,7 +63,7 @@ public class Enemy : MonoBehaviour
         if (!other.CompareTag("Bullet") || !_isLive)
             return;
 
-        health -= other.GetComponent<Bullet>().damage;
+        health -= other.GetComponent<Bullet>().WeaponInfo.Damage();
         StartCoroutine(KnockBack());
         if (health > 0)
         {

--- a/Assets/Scripts/ItemData.cs
+++ b/Assets/Scripts/ItemData.cs
@@ -43,6 +43,7 @@ public class ItemData : ScriptableObject
     public int baseCount;
     public float baseSpeed;
     public float baseRate;
+    public int basePer;
     
     [Header("# Level Data")]
     public float[] nextDamages = new float[MaxLevel];

--- a/Assets/Undead Survivor/Animations/Enemy/AcEnemy 0.controller
+++ b/Assets/Undead Survivor/Animations/Enemy/AcEnemy 0.controller
@@ -117,22 +117,22 @@ AnimatorStateMachine:
   m_ChildStates:
   - serializedVersion: 1
     m_State: {fileID: 5845195512510273010}
-    m_Position: {x: 30, y: 140, z: 0}
+    m_Position: {x: -80, y: 40, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 6060092035430956476}
-    m_Position: {x: 30, y: 220, z: 0}
+    m_Position: {x: -80, y: 120, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 7721464105759413891}
-    m_Position: {x: 30, y: -30, z: 0}
+    m_Position: {x: 150, y: 40, z: 0}
   m_ChildStateMachines: []
   m_AnyStateTransitions:
   - {fileID: 8815612957466924473}
   m_EntryTransitions: []
   m_StateMachineTransitions: {}
   m_StateMachineBehaviours: []
-  m_AnyStatePosition: {x: 50, y: -90, z: 0}
-  m_EntryPosition: {x: 50, y: 80, z: 0}
-  m_ExitPosition: {x: 50, y: 40, z: 0}
+  m_AnyStatePosition: {x: 170, y: -20, z: 0}
+  m_EntryPosition: {x: -60, y: -20, z: 0}
+  m_ExitPosition: {x: 170, y: 110, z: 0}
   m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}
   m_DefaultState: {fileID: 5845195512510273010}
 --- !u!1102 &5845195512510273010


### PR DESCRIPTION
1. count와 per를 분리해서 사용하기 위해 코드를 수정했다.
2. WeaponInfo 구조체 생성 :  무기에 대한 기본적인 정보들을 인자로 넘겨줄때가 많은데 이때 매개변수의 수가 많아지니 구조체를 선언해서 해당 구조체를 넘겨주면 더 편하게 쓰고 변수의 수도 줄일고, 데미지 연산같은 부분도 해당 구조체에 선언해서 사용하기위해 만들었다.