### PR TITLE
 Exp 획득 방식 변경

### DIFF
--- a/Assets/Prefabs/Exp.meta
+++ b/Assets/Prefabs/Exp.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 71067f1b75a744e5b9f7072874cde2ff
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Exp/Exp.prefab
+++ b/Assets/Prefabs/Exp/Exp.prefab
@@ -1,0 +1,120 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &8316010755521944017
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2107375967343256850}
+  - component: {fileID: 6148904133694761169}
+  - component: {fileID: -4703906338800868537}
+  - component: {fileID: -1774415351618594089}
+  m_Layer: 0
+  m_Name: Exp
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2107375967343256850
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8316010755521944017}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &6148904133694761169
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8316010755521944017}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 362616440, guid: 0d5e657ee5a074e4baa53d5b248a01d2, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 0.5555556, y: 0.6111111}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!114 &-4703906338800868537
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8316010755521944017}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: db7e7f1fcf07c43369ae8b11dd3b7907, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  sprite:
+  - {fileID: 362616440, guid: 0d5e657ee5a074e4baa53d5b248a01d2, type: 3}
+  - {fileID: 1807624531, guid: 0d5e657ee5a074e4baa53d5b248a01d2, type: 3}
+  - {fileID: -1997803578, guid: 0d5e657ee5a074e4baa53d5b248a01d2, type: 3}
+--- !u!70 &-1774415351618594089
+CapsuleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8316010755521944017}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_Size: {x: 0.5555556, y: 0.6111111}
+  m_Direction: 0

--- a/Assets/Prefabs/Exp/Exp.prefab.meta
+++ b/Assets/Prefabs/Exp/Exp.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 31941e24bcfbc4d36ae4901d1014d0df
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/GameScene.unity
+++ b/Assets/Scenes/GameScene.unity
@@ -761,65 +761,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 155235543}
   m_CullTransparentMesh: 1
---- !u!1 &198650290
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 198650292}
-  - component: {fileID: 198650293}
-  m_Layer: 0
-  m_Name: AudioManager
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &198650292
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 198650290}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 759.1422, y: 329.93472, z: 0.7148661}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &198650293
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 198650290}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7cbf47d37e88e4884bf56774526e0e7d, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  bgmClip: {fileID: 8300000, guid: 4559935c00ef8e94b846e2e03e39f0d0, type: 3}
-  bgmVolume: 0.2
-  sfxClips:
-  - {fileID: 8300000, guid: 291608b8d286e2a4580ff36324455ce2, type: 3}
-  - {fileID: 8300000, guid: 0bddcb411d826e14bb26d40ae45d8e22, type: 3}
-  - {fileID: 8300000, guid: 6b7eaf4532a2f614595ad58d2b86efc4, type: 3}
-  - {fileID: 8300000, guid: 64795b87003c2324fa0814fbc336066c, type: 3}
-  - {fileID: 8300000, guid: c8a3fe17a6641ec48b38fb455a40a223, type: 3}
-  - {fileID: 8300000, guid: 14f24de2a9a70154e96297de25e2184c, type: 3}
-  - {fileID: 8300000, guid: d1bef3102d08ba944ac7bcac65733a26, type: 3}
-  - {fileID: 8300000, guid: 6f0c572d865b4664db7a460972bc4768, type: 3}
-  - {fileID: 8300000, guid: 4b294d59d2399014daa718b35c9de73b, type: 3}
-  - {fileID: 8300000, guid: 2c4bc183a5df5aa4baf7c4fcf236a2de, type: 3}
-  sfxVolume: 0.5
-  channels: 16
 --- !u!1 &207815388
 GameObject:
   m_ObjectHideFlags: 0
@@ -2118,7 +2059,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &519420033
 MonoBehaviour:
@@ -2239,7 +2180,7 @@ AudioSource:
   m_Enabled: 1
   serializedVersion: 4
   OutputAudioMixerGroup: {fileID: 0}
-  m_audioClip: {fileID: 8300000, guid: 4559935c00ef8e94b846e2e03e39f0d0, type: 3}
+  m_audioClip: {fileID: 0}
   m_PlayOnAwake: 1
   m_Volume: 1
   m_Pitch: 1
@@ -9385,7 +9326,7 @@ Transform:
   m_Children:
   - {fileID: 1540640524}
   m_Father: {fileID: 0}
-  m_RootOrder: 0
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1122691033
 GameObject:
@@ -19052,11 +18993,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 79f92b53589e745d2be00d6c2e2b65b1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  id: 0
-  damage: 1000000
-  weaponType: 0
-  per: -1
-  speed: 0
 --- !u!61 &1333610395
 BoxCollider2D:
   m_ObjectHideFlags: 0
@@ -25048,6 +24984,54 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1665930373}
   m_CullTransparentMesh: 1
+--- !u!1 &1707467366
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1707467367}
+  - component: {fileID: 1707467368}
+  m_Layer: 0
+  m_Name: AreaMagnet
+  m_TagString: Magnet
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1707467367
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1707467366}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 771534}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!58 &1707467368
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1707467366}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  serializedVersion: 2
+  m_Radius: 1.5
 --- !u!1 &1722150761
 GameObject:
   m_ObjectHideFlags: 0
@@ -26904,10 +26888,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5c137f88616324f43be5ea3e75599768, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  prefabs:
-  - {fileID: 7374095405681530195, guid: c22ba27d630b3430aa9d111dd8b4cbac, type: 3}
-  - {fileID: 5588354483150353491, guid: 9e95e38965c0e4d6b83bf14efdf3aa58, type: 3}
-  - {fileID: 2773070785237260793, guid: df7d29b40a8754e978122ef4f9bd443d, type: 3}
   enemyPrefabs:
   - {fileID: 7374095405681530195, guid: c22ba27d630b3430aa9d111dd8b4cbac, type: 3}
   meleePrefabs:
@@ -26918,6 +26898,8 @@ MonoBehaviour:
   - {fileID: 2773070785237260793, guid: df7d29b40a8754e978122ef4f9bd443d, type: 3}
   - {fileID: 5588354483150353491, guid: 149e0ef29fd19425193e8c61e6b263e3, type: 3}
   - {fileID: 5588354483150353491, guid: 1ac08c3500f53445dbf0897c1f825b7a, type: 3}
+  expPrefabs:
+  - {fileID: 8316010755521944017, guid: 31941e24bcfbc4d36ae4901d1014d0df, type: 3}
 --- !u!1 &1930321980
 GameObject:
   m_ObjectHideFlags: 0
@@ -27456,3 +27438,62 @@ Transform:
   m_Father: {fileID: 1578027955}
   m_RootOrder: 11
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &2807435497647541232
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2807435497647541234}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 759.1422, y: 329.93472, z: 0.7148661}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2807435497647541233
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2807435497647541234}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7cbf47d37e88e4884bf56774526e0e7d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  bgmClip: {fileID: 8300000, guid: 4559935c00ef8e94b846e2e03e39f0d0, type: 3}
+  bgmVolume: 0.2
+  sfxClips:
+  - {fileID: 8300000, guid: 291608b8d286e2a4580ff36324455ce2, type: 3}
+  - {fileID: 8300000, guid: 0bddcb411d826e14bb26d40ae45d8e22, type: 3}
+  - {fileID: 8300000, guid: 6b7eaf4532a2f614595ad58d2b86efc4, type: 3}
+  - {fileID: 8300000, guid: 64795b87003c2324fa0814fbc336066c, type: 3}
+  - {fileID: 8300000, guid: c8a3fe17a6641ec48b38fb455a40a223, type: 3}
+  - {fileID: 8300000, guid: 14f24de2a9a70154e96297de25e2184c, type: 3}
+  - {fileID: 8300000, guid: d1bef3102d08ba944ac7bcac65733a26, type: 3}
+  - {fileID: 8300000, guid: 6f0c572d865b4664db7a460972bc4768, type: 3}
+  - {fileID: 8300000, guid: 4b294d59d2399014daa718b35c9de73b, type: 3}
+  - {fileID: 8300000, guid: 2c4bc183a5df5aa4baf7c4fcf236a2de, type: 3}
+  sfxVolume: 0.5
+  channels: 16
+--- !u!1 &2807435497647541234
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2807435497647541232}
+  - component: {fileID: 2807435497647541233}
+  m_Layer: 0
+  m_Name: AudioManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1

--- a/Assets/Scenes/MainScene.unity
+++ b/Assets/Scenes/MainScene.unity
@@ -123,6 +123,65 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &66674961
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 66674963}
+  - component: {fileID: 66674962}
+  m_Layer: 0
+  m_Name: AudioManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &66674962
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 66674961}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7cbf47d37e88e4884bf56774526e0e7d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  bgmClip: {fileID: 8300000, guid: 4559935c00ef8e94b846e2e03e39f0d0, type: 3}
+  bgmVolume: 0.2
+  sfxClips:
+  - {fileID: 8300000, guid: 291608b8d286e2a4580ff36324455ce2, type: 3}
+  - {fileID: 8300000, guid: 0bddcb411d826e14bb26d40ae45d8e22, type: 3}
+  - {fileID: 8300000, guid: 6b7eaf4532a2f614595ad58d2b86efc4, type: 3}
+  - {fileID: 8300000, guid: 64795b87003c2324fa0814fbc336066c, type: 3}
+  - {fileID: 8300000, guid: c8a3fe17a6641ec48b38fb455a40a223, type: 3}
+  - {fileID: 8300000, guid: 14f24de2a9a70154e96297de25e2184c, type: 3}
+  - {fileID: 8300000, guid: d1bef3102d08ba944ac7bcac65733a26, type: 3}
+  - {fileID: 8300000, guid: 6f0c572d865b4664db7a460972bc4768, type: 3}
+  - {fileID: 8300000, guid: 4b294d59d2399014daa718b35c9de73b, type: 3}
+  - {fileID: 8300000, guid: 2c4bc183a5df5aa4baf7c4fcf236a2de, type: 3}
+  sfxVolume: 0.5
+  channels: 16
+--- !u!4 &66674963
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 66674961}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 759.1422, y: 329.93472, z: 0.7148661}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &112579140
 GameObject:
   m_ObjectHideFlags: 0
@@ -329,7 +388,6 @@ MonoBehaviour:
   maxGameTime: 300
   isLive: 0
   data: {fileID: 0}
-  playerId: 0
   level: 0
   kill: 0
   exp: 0
@@ -349,67 +407,8 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &198650290
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 198650292}
-  - component: {fileID: 198650293}
-  m_Layer: 0
-  m_Name: AudioManager
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &198650292
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 198650290}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 759.1422, y: 329.93472, z: 0.7148661}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &198650293
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 198650290}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7cbf47d37e88e4884bf56774526e0e7d, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  bgmClip: {fileID: 8300000, guid: 4559935c00ef8e94b846e2e03e39f0d0, type: 3}
-  bgmVolume: 0.2
-  sfxClips:
-  - {fileID: 8300000, guid: 291608b8d286e2a4580ff36324455ce2, type: 3}
-  - {fileID: 8300000, guid: 0bddcb411d826e14bb26d40ae45d8e22, type: 3}
-  - {fileID: 8300000, guid: 6b7eaf4532a2f614595ad58d2b86efc4, type: 3}
-  - {fileID: 8300000, guid: 64795b87003c2324fa0814fbc336066c, type: 3}
-  - {fileID: 8300000, guid: c8a3fe17a6641ec48b38fb455a40a223, type: 3}
-  - {fileID: 8300000, guid: 14f24de2a9a70154e96297de25e2184c, type: 3}
-  - {fileID: 8300000, guid: d1bef3102d08ba944ac7bcac65733a26, type: 3}
-  - {fileID: 8300000, guid: 6f0c572d865b4664db7a460972bc4768, type: 3}
-  - {fileID: 8300000, guid: 4b294d59d2399014daa718b35c9de73b, type: 3}
-  - {fileID: 8300000, guid: 2c4bc183a5df5aa4baf7c4fcf236a2de, type: 3}
-  sfxVolume: 0.5
-  channels: 16
 --- !u!1 &256932049
 GameObject:
   m_ObjectHideFlags: 0
@@ -1406,11 +1405,11 @@ AudioSource:
   m_Enabled: 1
   serializedVersion: 4
   OutputAudioMixerGroup: {fileID: 0}
-  m_audioClip: {fileID: 8300000, guid: 4559935c00ef8e94b846e2e03e39f0d0, type: 3}
-  m_PlayOnAwake: 1
+  m_audioClip: {fileID: 0}
+  m_PlayOnAwake: 0
   m_Volume: 1
   m_Pitch: 1
-  Loop: 0
+  Loop: 1
   Mute: 0
   Spatialize: 0
   SpatializePostEffects: 0

--- a/Assets/Scripts/AudioManager.cs
+++ b/Assets/Scripts/AudioManager.cs
@@ -41,8 +41,8 @@ public class AudioManager : MonoBehaviour
             Destroy(this.gameObject);
         else
             _instance = this;
-
         Init();
+        PlayBgm(true);
     }
 
     private void Init()
@@ -55,7 +55,6 @@ public class AudioManager : MonoBehaviour
         _bgmPlayer.volume = bgmVolume;
         _bgmPlayer.clip = bgmClip;
         _bgmEffect = Camera.main.GetComponent<AudioHighPassFilter>();
-        
         
         GameObject sfxObject = new GameObject("SfxPlayer");
         sfxObject.transform.parent = transform;

--- a/Assets/Scripts/Enemy.cs
+++ b/Assets/Scripts/Enemy.cs
@@ -41,7 +41,6 @@ public class Enemy : MonoBehaviour
     }
     private void LateUpdate()
     {
-        
         if (!_gameManager.isLive)
             return;
         if (!_isLive)
@@ -78,8 +77,9 @@ public class Enemy : MonoBehaviour
             _spriter.sortingOrder = 1;
             _anim.SetBool("Dead", true);
             _gameManager.kill++;
-            _gameManager.GetExp();
-            
+            Exp exp = _gameManager.pool.GetExp(0);
+            exp.Init(0);
+            exp.transform.position = transform.position;
             if (_gameManager.isLive)
                 AudioManager.Instance.PlaySfx(AudioManager.Sfx.Dead);
         }

--- a/Assets/Scripts/Exp.cs
+++ b/Assets/Scripts/Exp.cs
@@ -1,0 +1,70 @@
+using System;
+using UnityEngine;
+
+public class Exp : MonoBehaviour
+{
+    public enum ExpType
+    {
+        Normal = 0,
+        Elite = 1,
+        Boss = 2,
+    }
+
+    public Sprite[] sprite;
+    private ExpType _type;
+    private SpriteRenderer _spriter;
+    private Transform _target = null;
+    private GameManager _gameManager;
+    private float speed = 10.0f; // 움직일 속도
+
+
+    private void Awake()
+    {
+        _gameManager = GameManager.Instance;
+        _spriter = GetComponent<SpriteRenderer>();
+    }
+
+    private void OnEnable()
+    {
+        _target = null;
+    }
+
+    private void FixedUpdate()
+    {
+        if (!_gameManager.isLive)
+            return;
+        if (!_target)
+            return;
+        Move();
+    }
+    
+    private void Move()
+    {
+        transform.position = Vector3.MoveTowards(transform.position, _target.position, speed * Time.fixedDeltaTime);
+    }
+    
+
+    public void Init(ExpType type)
+    {
+        _type = type;
+        _spriter.sprite = sprite[(int)_type];
+    }
+
+    public void Follow(Transform target)
+    {
+        _target = target;
+    }
+
+    private void OnTriggerEnter2D(Collider2D other)
+    {
+        if (other.CompareTag("Magnet"))
+            Follow(other.transform);
+        if (other.CompareTag("Player"))
+        {
+            _gameManager.GetExp((int)_type * 2 + 1);
+            
+            AudioManager.Instance.PlaySfx(AudioManager.Sfx.Select);
+            gameObject.SetActive(false);
+        }
+    }
+}

--- a/Assets/Scripts/Exp.cs.meta
+++ b/Assets/Scripts/Exp.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: db7e7f1fcf07c43369ae8b11dd3b7907
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -21,7 +21,6 @@ public class GameManager : MonoBehaviour
 
     [Header("# Player Info")]
     public CharacterData data;
-    public int playerId;
     public int level = 0;
     public int kill;
     public int exp;
@@ -133,14 +132,14 @@ public class GameManager : MonoBehaviour
             GameVictory();
         }
     }
-    public void GetExp()
+    public void GetExp(int exp)
     {
         if (!isLive)
             return;
-        exp++;
+        this.exp += exp;
         if (level < nextExp.Length && exp >= nextExp[Mathf.Min(level, nextExp.Length - 1)])
         {
-            exp -= nextExp[level];
+            this.exp -= nextExp[level];
             level++;
             uiLevelUp.Show();
         }

--- a/Assets/Scripts/PoolManager.cs
+++ b/Assets/Scripts/PoolManager.cs
@@ -1,25 +1,20 @@
-using System;
 using System.Collections.Generic;
-using Unity.VisualScripting;
 using UnityEngine;
 
 public class PoolManager : MonoBehaviour
 {
-    public GameObject[] prefabs;
     public GameObject[] enemyPrefabs;
     public GameObject[] meleePrefabs;
     public GameObject[] rangePrefabs;
-    private List<GameObject>[] _pools;
+    public GameObject[] expPrefabs;
+    
     private List<Enemy>[] _enemyPools;
     private List<Bullet>[] _meleePools;
     private List<Bullet>[] _rangePools;
+    private List<Exp>[] _expPools;
 
     private void Awake()
     {
-        _pools = new List<GameObject>[prefabs.Length];
-        for (int i = 0; i < _pools.Length; i++)
-            _pools[i] = new List<GameObject>();
-        
         _enemyPools = new List<Enemy>[enemyPrefabs.Length];
         for (int i = 0; i < _enemyPools.Length; i++)
             _enemyPools[i] = new List<Enemy>();
@@ -31,28 +26,12 @@ public class PoolManager : MonoBehaviour
         _rangePools = new List<Bullet>[rangePrefabs.Length];
         for (int i = 0; i < _rangePools.Length; i++)
             _rangePools[i] = new List<Bullet>();
+        
+        _expPools = new List<Exp>[expPrefabs.Length];
+        for (int i = 0; i < _expPools.Length; i++)
+            _expPools[i] = new List<Exp>();
     }
 
-    public GameObject Get(int index)
-    {
-        GameObject select = null;
-
-        foreach (GameObject item in _pools[index])
-        {
-            if (!item.activeSelf)
-            {
-                select = item;
-                select.SetActive(true);
-                break;
-            }
-        }
-        if (!select)
-        {
-            select = Instantiate(prefabs[index], transform);
-            _pools[index].Add(select);
-        }
-        return select;
-    }  
     public Enemy GetEnemy(int index)
     {
         Enemy select = null;
@@ -111,6 +90,27 @@ public class PoolManager : MonoBehaviour
         {
             select = Instantiate(rangePrefabs[index], transform).GetComponent<Bullet>();
             _rangePools[index].Add(select);
+        }
+        return select;
+    }
+    
+    public Exp GetExp(int index)
+    {
+        Exp select = null;
+
+        foreach (Exp item in _expPools[index])
+        {
+            if (!item.gameObject.activeSelf)
+            {
+                select = item;
+                select.gameObject.SetActive(true);
+                break;
+            }
+        }
+        if (!select)
+        {
+            select = Instantiate(expPrefabs[index], transform).GetComponent<Exp>();
+            _expPools[index].Add(select);
         }
         return select;
     }

--- a/Assets/Scripts/Spawner.cs
+++ b/Assets/Scripts/Spawner.cs
@@ -33,9 +33,6 @@ public class Spawner : MonoBehaviour
 
     void Spawn()
     {
-        // GameObject enemy = _gameManager.pool.Get(0);
-        // enemy.transform.position = spawnPoint[Random.Range(1, spawnPoint.Length)].position;
-        // enemy.GetComponent<Enemy>().Init(spawnDatas[_level]);
         Enemy enemy = _gameManager.pool.GetEnemy(0);
         enemy.transform.position = spawnPoint[Random.Range(1, spawnPoint.Length)].position;
         enemy.Init(spawnDatas[_level]);

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -8,6 +8,7 @@ TagManager:
   - Area
   - Enemy
   - Bullet
+  - Magnet
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
기존의 exp 획득방식은 enemy를 처치시 자동 획득이였지만 처치시 exp 아이템을 드랍하고 해당 exp 아이템을 획득하면 player의 exp가 올라가는 방식으로 변경

Exp 객체를 생성하고, Enemy를 처치 시 exp 아이템이 드랍, player의 magnet 범위 안에 exp 아이템이 있으면 exp는 player를 타겟으로 이동 후 player와 닿으면 해당 exp를 획득하게 했다.